### PR TITLE
Check for snmpv3 before enforcing v3_password

### DIFF
--- a/src/middlewared/middlewared/plugins/snmp.py
+++ b/src/middlewared/middlewared/plugins/snmp.py
@@ -37,7 +37,7 @@ class SNMPService(SystemServiceService):
         if not new['v3'] and not new['community']:
             verrors.add('snmp_update.community', 'This field is required when SNMPv3 is disabled')
 
-        if new['v3_authtype'] and not new['v3_password']:
+        if new['v3'] and new['v3_authtype'] and not new['v3_password']:
             verrors.add(
                 'snmp_update.v3_password',
                 'This field is requires when SNMPv3 auth type is specified',


### PR DESCRIPTION
Enforcing snmpv3 password when v3 is not indicated to be used causes issues with updating any other attributes until v3_authtype is unset or a dummy v3_password is set.